### PR TITLE
Add name column to users table

### DIFF
--- a/db/migrate/20170415071219_add_name_to_users.rb
+++ b/db/migrate/20170415071219_add_name_to_users.rb
@@ -1,0 +1,6 @@
+class AddNameToUsers < ActiveRecord::Migration[5.0]
+  def change
+    add_column :users, :name, :string, null: false
+    add_index :users, :name, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170415023552) do
+ActiveRecord::Schema.define(version: 20170415071219) do
 
   create_table "users", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string   "email",                  default: "", null: false
@@ -25,7 +25,9 @@ ActiveRecord::Schema.define(version: 20170415023552) do
     t.string   "last_sign_in_ip"
     t.datetime "created_at",                          null: false
     t.datetime "updated_at",                          null: false
+    t.string   "name",                                null: false
     t.index ["email"], name: "index_users_on_email", unique: true, using: :btree
+    t.index ["name"], name: "index_users_on_name", unique: true, using: :btree
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true, using: :btree
   end
 


### PR DESCRIPTION
# WHAT
データベース設計に従って、usersテーブルにnameカラムを追加

# WHY
ユーザー管理機能に必要なカラムだが、「rails g devise user」では生成されないため、自分で追加する必要があるため

## 補足
一意性制約（indexも同時に付与される）とNOT NULL制約も付与する形でカラムを追加

### 作業終了後のテーブルの構造↓
![2017-04-15 18 09 11](https://cloud.githubusercontent.com/assets/25572309/25062480/d42cc16c-2207-11e7-9d5b-7d6b842d3081.png)
