### PR TITLE
permit 'name' column as a strong parameter

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,5 +6,6 @@ class ApplicationController < ActionController::Base
 
   def configure_permitted_parameters
     devise_parameter_sanitizer.permit(:sign_up, keys: [:name])
+    devise_parameter_sanitizer.permit(:account_update, keys: [:name])
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,4 +2,9 @@ class ApplicationController < ActionController::Base
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception
+  before_action :configure_permitted_parameters, if: :devise_controller?
+
+  def configure_permitted_parameters
+    devise_parameter_sanitizer.permit(:sign_up, keys: [:name])
+  end
 end


### PR DESCRIPTION
# WHAT
usersテーブルに追加したnameカラムをストロングパラメーターに追加し、受け取りを許可する（deviseのsign_upアクションに対して、nameカラムをストロングパラメーターとして追加する）

# WHY
deviseで生成したテーブルに新たに追加したカラムは、初期状態では受け取りが許可されていないため