### PR TITLE
Override Devise  RegistrationsController to allow users to edit their account without providing a password

### DIFF
--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -1,0 +1,15 @@
+class Users::RegistrationsController < Devise::RegistrationsController
+
+protected
+
+#update_without_password：Deviseに実装されている、パスワードなしで更新を行うメソッド
+#パスワードなしでユーザーのアカウント情報を更新できるようになる
+#ただしパスワードの更新には現在のパスワードの入力が必要なので、↓のメソッドを使う
+#update_without_current_password：models/user.rbに自分で定義したメソッド
+#現在のパスワードの入力無しでもパスワードの更新をできるようにした
+
+  def update_resource(resource, params)
+    resource.update_without_current_password(params)
+  end
+
+end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -8,8 +8,8 @@ protected
 #update_without_current_password：models/user.rbに自分で定義したメソッド
 #現在のパスワードの入力無しでもパスワードの更新をできるようにした
 
-  def update_resource(resource, params)
-    resource.update_without_current_password(params)
-  end
+def update_resource(resource, params)
+  resource.update_without_current_password(params)
+end
 
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,4 +3,19 @@ class User < ApplicationRecord
   # :confirmable, :lockable, :timeoutable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :trackable, :validatable
+
+  # allow users to update their accounts without passwords
+  def update_without_current_password(params, *options)
+    params.delete(:current_password)
+
+    if params[:password].blank? && params[:password_confirmation].blank?
+      params.delete(:password)
+      params.delete(:password_confirmation)
+    end
+
+    result = update_attributes(params, *options)
+    clean_up_passwords
+    result
+  end
+
 end

--- a/app/views/devise/registrations/edit.html.haml
+++ b/app/views/devise/registrations/edit.html.haml
@@ -29,11 +29,5 @@
             = f.label :password_confirmation
           .field-input
             = f.password_field :password_confirmation, autocomplete: "off"
-        .field
-          .field-label
-            = f.label :current_password
-            %i (変更には現在のパスワードの入力が必要です)
-          .field-input
-            = f.password_field :current_password, autocomplete: "off"
         .actions
           = f.submit "Update", class: 'btn'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,6 @@
 Rails.application.routes.draw do
   devise_for :users, controllers: {
-  registrations: "users/registrations"
+    registrations: 'users/registrations'
   }
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
   root 'messages#index'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,7 @@
 Rails.application.routes.draw do
-  devise_for :users
+  devise_for :users, :controllers => {
+  :registrations => "users/registrations"
+  }
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
   root 'messages#index'
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,6 @@
 Rails.application.routes.draw do
-  devise_for :users, :controllers => {
-  :registrations => "users/registrations"
+  devise_for :users, controllers: {
+  registrations: "users/registrations"
   }
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
   root 'messages#index'


### PR DESCRIPTION
# WHAT
Devise のデフォルトのユーザーアカウント編集のためのアクション（devise/registrations#update）では、現在のパスワードの入力が必須となっているが、これをパスワードなしで更新できるように変更する。

# WHY
よりよいUXを提供するため

## 具体的な変更内容
1. Devise::RegistrationsControllerをカスタマイズするためのコントローラー（registrations_controller.rb）を作る
1. 上記1で作成したregistrations_controller.rbにて、controllers/devise/registrations_controller.rbのupdateアクション内で呼び出されているupdate_resourceメソッドをオーバーライドする
1. アカウント編集画面のビュー（views/devise/registrations/edit.html.haml）から、現在のパスワードの入力欄を削除する
1. 上記1のカスタマイズ用のコントローラーを参照するようにルーティングを書き換える

#### 参考にしたページ
http://easyramble.com/user-account-update-without-password-on-devise.html
http://easyramble.com/cutomize-controllers-on-rails-devise.html 
https://github.com/plataformatec/devise/blob/master/app/controllers/devise/registrations_controller.rb
http://www.rubydoc.info/github/plataformatec/devise/Devise%2FModels%2FDatabaseAuthenticatable%3Aupdate_with_password
http://www.rubydoc.info/github/plataformatec/devise/Devise%2FModels%2FDatabaseAuthenticatable%3Aupdate_without_password

#### 変更後のルーティング（青ハイライト部分が変更が加わったルーティング）
![2017-04-18 17 01 21](https://cloud.githubusercontent.com/assets/25572309/25120379/bbd5fc16-2458-11e7-84df-bd939579729c.png)


#### 変更後のアカウント編集ページ（「現在のパスワード」入力欄を削除）
![2017-04-18 16 22 28](https://cloud.githubusercontent.com/assets/25572309/25119857/cbb261b2-2456-11e7-8a55-fa774887b7bc.png)
