### PR TITLE
Define url redirection

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,4 +8,10 @@ class ApplicationController < ActionController::Base
     devise_parameter_sanitizer.permit(:sign_up, keys: [:name])
     devise_parameter_sanitizer.permit(:account_update, keys: [:name])
   end
+
+  # サインアウト後にサインインページにリダイレクトさせる
+  def after_sign_out_path_for(resource)
+    new_user_session_path
+  end
+
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,6 +2,10 @@ class ApplicationController < ActionController::Base
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception
+
+  # 非ログ時はサインインページにリダイレクトさせる
+  before_action :authenticate_user!
+
   before_action :configure_permitted_parameters, if: :devise_controller?
 
   def configure_permitted_parameters

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,6 +8,8 @@ class ApplicationController < ActionController::Base
 
   before_action :configure_permitted_parameters, if: :devise_controller?
 
+  private
+
   def configure_permitted_parameters
     devise_parameter_sanitizer.permit(:sign_up, keys: [:name])
     devise_parameter_sanitizer.permit(:account_update, keys: [:name])

--- a/app/views/messages/index.html.haml
+++ b/app/views/messages/index.html.haml
@@ -10,7 +10,7 @@
       .chat-side__user-name
         login_username
       .chat-side__user--edit-user
-        = link_to 'https://www.google.co.jp/' do
+        = link_to edit_user_registration_path do
           %i.fa.fa-cog
       .chat-side__user--new-group
         = link_to 'https://www.google.co.jp/' do

--- a/app/views/messages/index.html.haml
+++ b/app/views/messages/index.html.haml
@@ -8,7 +8,7 @@
 
     .chat-side__user-content
       .chat-side__user-name
-        login_username
+        = current_user.name
       .chat-side__user--edit-user
         = link_to edit_user_registration_path do
           %i.fa.fa-cog


### PR DESCRIPTION
# WHAT
以下の２つのリダイレクトを設定
1. サインアウト後にサインインページにリダイレクトさせる
1. 非ログイン時はサインインページにリダイレクトさせる

その他細かい修正有り
- ユーザー情報編集ページに飛ぶためのアイコンに正しいパスを付与
- トップページ左カラム上部にて、ログインユーザーのname属性を表示

# WHY
よりよいUXを提供するため

