### PR TITLE
generate group model & groups controller

### DIFF
--- a/app/assets/javascripts/groups.coffee
+++ b/app/assets/javascripts/groups.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/stylesheets/groups.scss
+++ b/app/assets/stylesheets/groups.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the groups controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -1,0 +1,2 @@
+class GroupsController < ApplicationController
+end

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -1,0 +1,2 @@
+class Group < ApplicationRecord
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,5 +3,8 @@ Rails.application.routes.draw do
     registrations: 'users/registrations'
   }
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
+
+  resources :groups, except: [:show, :destroy]
+
   root 'messages#index'
 end

--- a/db/migrate/20170421045701_create_groups.rb
+++ b/db/migrate/20170421045701_create_groups.rb
@@ -1,0 +1,8 @@
+class CreateGroups < ActiveRecord::Migration[5.0]
+  def change
+    create_table :groups do |t|
+      t.string :name, null: false
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,13 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170415071219) do
+ActiveRecord::Schema.define(version: 20170421045701) do
+
+  create_table "groups", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+    t.string   "name",       null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
 
   create_table "users", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string   "email",                  default: "", null: false


### PR DESCRIPTION
# WHAT
- groupモデルの生成
  - DB設計に従い、nameカラム（NOT NULL制約有り）を追加
- groupsコントローラーの生成
- groupsのルーティング設定
  - showアクションとdestroyアクションは不要なため未設定

# WHY
グループ機能を実装するため

### groupsテーブルの構造↓

![2017-04-21 14 46 04](https://cloud.githubusercontent.com/assets/25572309/25264347/447766d2-26a1-11e7-85ef-e65e55468252.png)

### 新規追加したルーティング↓

![2017-04-21 14 40 03](https://cloud.githubusercontent.com/assets/25572309/25264337/35b7f152-26a1-11e7-8306-62d85e0e0ef5.png)

