### PR TITLE
Create the view of group#edit and add group update function

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -1,5 +1,7 @@
 class GroupsController < ApplicationController
 
+  before_action :set_group, only: [:edit, :update]
+
   def new
     @group = Group.new
   end
@@ -15,11 +17,9 @@ class GroupsController < ApplicationController
   end
 
   def edit
-    @group = Group.find(params[:id])
   end
 
   def update
-    @group = Group.find(params[:id])
     if @group.update(group_params)
       redirect_to root_path, notice: 'グループが更新されました'
     else
@@ -34,6 +34,10 @@ class GroupsController < ApplicationController
     params[:group][:user_ids].push(current_user.id.to_s)
     # :user_idsは配列なので、書き方が↓のように特殊な形となる
     params.require(:group).permit(:name, user_ids: [])
+  end
+
+  def set_group
+    @group = Group.find(params[:id])
   end
 
 end

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -7,8 +7,7 @@ class GroupsController < ApplicationController
   def create
     @group = Group.new(group_params)
     if @group.save
-      flash.notice = '新規グループが作成されました。'
-      redirect_to root_path
+      redirect_to root_path, notice: '新規グループが作成されました。'
     else
       flash.now.alert = 'グループ名を入力して下さい'
       render :new
@@ -22,8 +21,7 @@ class GroupsController < ApplicationController
   def update
     @group = Group.find(params[:id])
     if @group.update(group_params)
-      flash.notice = 'グループが更新されました'
-      redirect_to root_path
+      redirect_to root_path, notice: 'グループが更新されました'
     else
       flash.now.alert = 'グループ名を入力して下さい'
       render :edit

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -15,6 +15,21 @@ class GroupsController < ApplicationController
     end
   end
 
+  def edit
+    @group = Group.find(params[:id])
+  end
+
+  def update
+    @group = Group.find(params[:id])
+    if @group.update(group_params)
+      flash.notice = 'グループが更新されました'
+      redirect_to root_path
+    else
+      flash.now.alert = 'グループ名を入力して下さい'
+      render :edit
+    end
+  end
+
   private
   def group_params
     # ログインユーザーのidを、collection_check_boxes経由で送られてきた配列user_idsに、文字列型で追加する

--- a/app/helpers/group_helper.rb
+++ b/app/helpers/group_helper.rb
@@ -1,0 +1,5 @@
+module GroupHelper
+  def render_partial_template
+    current_page?(action: :new)? '新規チャットグループ' : 'チャットグループ編集'
+  end
+end

--- a/app/views/groups/_group_form.html.haml
+++ b/app/views/groups/_group_form.html.haml
@@ -1,7 +1,7 @@
 =form_for @group do |f|
   .chat-group-form__field
     .chat-group-form__field--left
-      %label.chat-group-form__label{:for => "chat_group_name"} グループ名
+      %label.chat-group-form__label{for: "chat_group_name"} グループ名
     .chat-group-form__field--right
       =f.text_field :name, placeholder: 'グループ名を入力してください'
 
@@ -17,7 +17,7 @@
   / メンバー追加（collection_check_boxe用）
   .chat-group-form__field
     .chat-group-form__field--left
-      %label.chat-group-form__label{:for => "chat_group_チャットメンバー"} チャットメンバー
+      %label.chat-group-form__label{for: "chat_group_チャットメンバー"} チャットメンバー
     .chat-group-form__field--right
       #chat-group-users
         .chat-group-user

--- a/app/views/groups/_group_form.html.haml
+++ b/app/views/groups/_group_form.html.haml
@@ -1,0 +1,30 @@
+=form_for @group do |f|
+  .chat-group-form__field
+    .chat-group-form__field--left
+      %label.chat-group-form__label{:for => "chat_group_name"} グループ名
+    .chat-group-form__field--right
+      =f.text_field :name, placeholder: 'グループ名を入力してください'
+
+  / メンバー追加（インクリメンタルサーチ用）
+  / .chat-group-form__field
+  /   .chat-group-form__field--left
+  /     %label.chat-group-form__label{:for => "chat_group_チャットメンバーを追加"} チャットメンバーを追加
+  /   .chat-group-form__field--right
+  /     .chat-group-form__search
+  /       %input#user-search-field.chat-group-form__input{:placeholder => "追加したいユーザー名を入力してください", :type => "text"}/
+  /     #user-search-result
+
+  / メンバー追加（collection_check_boxe用）
+  .chat-group-form__field
+    .chat-group-form__field--left
+      %label.chat-group-form__label{:for => "chat_group_チャットメンバー"} チャットメンバー
+    .chat-group-form__field--right
+      #chat-group-users
+        .chat-group-user
+          / ログインユーザーのチェックボックスは表示させないようにする
+          = collection_check_boxes(:group, :user_ids, User.where.not(id: current_user.id), :id, :name)
+
+  .chat-group-form__field
+    .chat-group-form__field--left
+    .chat-group-form__field--right
+      = f.submit 'Save', class: 'chat-group-form__action-btn'

--- a/app/views/groups/_group_form.html.haml
+++ b/app/views/groups/_group_form.html.haml
@@ -2,33 +2,33 @@
   %h1
     = render_partial_template
 
-=form_for @group do |f|
-  .chat-group-form__field
-    .chat-group-form__field--left
-      %label.chat-group-form__label{for: "chat_group_name"} グループ名
-    .chat-group-form__field--right
-      =f.text_field :name, placeholder: 'グループ名を入力してください'
+  =form_for @group do |f|
+    .chat-group-form__field
+      .chat-group-form__field--left
+        %label.chat-group-form__label{for: "chat_group_name"} グループ名
+      .chat-group-form__field--right
+        =f.text_field :name, placeholder: 'グループ名を入力してください'
 
-  / メンバー追加（インクリメンタルサーチ用）
-  / .chat-group-form__field
-  /   .chat-group-form__field--left
-  /     %label.chat-group-form__label{:for => "chat_group_チャットメンバーを追加"} チャットメンバーを追加
-  /   .chat-group-form__field--right
-  /     .chat-group-form__search
-  /       %input#user-search-field.chat-group-form__input{:placeholder => "追加したいユーザー名を入力してください", :type => "text"}/
-  /     #user-search-result
+    / メンバー追加（インクリメンタルサーチ用）
+    / .chat-group-form__field
+    /   .chat-group-form__field--left
+    /     %label.chat-group-form__label{:for => "chat_group_チャットメンバーを追加"} チャットメンバーを追加
+    /   .chat-group-form__field--right
+    /     .chat-group-form__search
+    /       %input#user-search-field.chat-group-form__input{:placeholder => "追加したいユーザー名を入力してください", :type => "text"}/
+    /     #user-search-result
 
-  / メンバー追加（collection_check_boxe用）
-  .chat-group-form__field
-    .chat-group-form__field--left
-      %label.chat-group-form__label{for: "chat_group_チャットメンバー"} チャットメンバー
-    .chat-group-form__field--right
-      #chat-group-users
-        .chat-group-user
-          / ログインユーザーのチェックボックスは表示させないようにする
-          = collection_check_boxes(:group, :user_ids, User.where.not(id: current_user.id), :id, :name)
+    / メンバー追加（collection_check_boxe用）
+    .chat-group-form__field
+      .chat-group-form__field--left
+        %label.chat-group-form__label{for: "chat_group_チャットメンバー"} チャットメンバー
+      .chat-group-form__field--right
+        #chat-group-users
+          .chat-group-user
+            / ログインユーザーのチェックボックスは表示させないようにする
+            = collection_check_boxes(:group, :user_ids, User.where.not(id: current_user.id), :id, :name)
 
-  .chat-group-form__field
-    .chat-group-form__field--left
-    .chat-group-form__field--right
-      = f.submit 'Save', class: 'chat-group-form__action-btn'
+    .chat-group-form__field
+      .chat-group-form__field--left
+      .chat-group-form__field--right
+        = f.submit 'Save', class: 'chat-group-form__action-btn'

--- a/app/views/groups/_group_form.html.haml
+++ b/app/views/groups/_group_form.html.haml
@@ -1,3 +1,7 @@
+.chat-group-form
+  %h1
+    = render_partial_template
+
 =form_for @group do |f|
   .chat-group-form__field
     .chat-group-form__field--left

--- a/app/views/groups/edit.html.haml
+++ b/app/views/groups/edit.html.haml
@@ -1,0 +1,33 @@
+.chat-group-form
+  %h1 新規チャットグループ
+  =form_for @group do |f|
+
+    .chat-group-form__field
+      .chat-group-form__field--left
+        %label.chat-group-form__label{:for => "chat_group_name"} グループ名
+      .chat-group-form__field--right
+        =f.text_field :name, placeholder: 'グループ名を入力してください'
+
+    / メンバー追加（インクリメンタルサーチ用）
+    / .chat-group-form__field
+    /   .chat-group-form__field--left
+    /     %label.chat-group-form__label{:for => "chat_group_チャットメンバーを追加"} チャットメンバーを追加
+    /   .chat-group-form__field--right
+    /     .chat-group-form__search
+    /       %input#user-search-field.chat-group-form__input{:placeholder => "追加したいユーザー名を入力してください", :type => "text"}/
+    /     #user-search-result
+
+    / メンバー追加（collection_check_boxe用）
+    .chat-group-form__field
+      .chat-group-form__field--left
+        %label.chat-group-form__label{:for => "chat_group_チャットメンバー"} チャットメンバー
+      .chat-group-form__field--right
+        #chat-group-users
+          .chat-group-user
+            / ログインユーザーのチェックボックスは表示させないようにする
+            = collection_check_boxes(:group, :user_ids, User.where.not(id: current_user.id), :id, :name)
+
+    .chat-group-form__field
+      .chat-group-form__field--left
+      .chat-group-form__field--right
+        = f.submit 'Save', class: 'chat-group-form__action-btn'

--- a/app/views/groups/edit.html.haml
+++ b/app/views/groups/edit.html.haml
@@ -1,3 +1,1 @@
-.chat-group-form
-  %h1 チャットグループ編集
-  =render 'group_form'
+= render 'group_form'

--- a/app/views/groups/edit.html.haml
+++ b/app/views/groups/edit.html.haml
@@ -1,33 +1,3 @@
 .chat-group-form
-  %h1 新規チャットグループ
-  =form_for @group do |f|
-
-    .chat-group-form__field
-      .chat-group-form__field--left
-        %label.chat-group-form__label{:for => "chat_group_name"} グループ名
-      .chat-group-form__field--right
-        =f.text_field :name, placeholder: 'グループ名を入力してください'
-
-    / メンバー追加（インクリメンタルサーチ用）
-    / .chat-group-form__field
-    /   .chat-group-form__field--left
-    /     %label.chat-group-form__label{:for => "chat_group_チャットメンバーを追加"} チャットメンバーを追加
-    /   .chat-group-form__field--right
-    /     .chat-group-form__search
-    /       %input#user-search-field.chat-group-form__input{:placeholder => "追加したいユーザー名を入力してください", :type => "text"}/
-    /     #user-search-result
-
-    / メンバー追加（collection_check_boxe用）
-    .chat-group-form__field
-      .chat-group-form__field--left
-        %label.chat-group-form__label{:for => "chat_group_チャットメンバー"} チャットメンバー
-      .chat-group-form__field--right
-        #chat-group-users
-          .chat-group-user
-            / ログインユーザーのチェックボックスは表示させないようにする
-            = collection_check_boxes(:group, :user_ids, User.where.not(id: current_user.id), :id, :name)
-
-    .chat-group-form__field
-      .chat-group-form__field--left
-      .chat-group-form__field--right
-        = f.submit 'Save', class: 'chat-group-form__action-btn'
+  %h1 チャットグループ編集
+  =render 'group_form'

--- a/app/views/groups/new.html.haml
+++ b/app/views/groups/new.html.haml
@@ -1,3 +1,1 @@
-.chat-group-form
-  %h1 新規チャットグループ
-  =render 'group_form'
+= render 'group_form'

--- a/app/views/groups/new.html.haml
+++ b/app/views/groups/new.html.haml
@@ -1,33 +1,3 @@
 .chat-group-form
   %h1 新規チャットグループ
-  =form_for @group do |f|
-
-    .chat-group-form__field
-      .chat-group-form__field--left
-        %label.chat-group-form__label{:for => "chat_group_name"} グループ名
-      .chat-group-form__field--right
-        =f.text_field :name, placeholder: 'グループ名を入力してください'
-
-    / メンバー追加（インクリメンタルサーチ用）
-    / .chat-group-form__field
-    /   .chat-group-form__field--left
-    /     %label.chat-group-form__label{:for => "chat_group_チャットメンバーを追加"} チャットメンバーを追加
-    /   .chat-group-form__field--right
-    /     .chat-group-form__search
-    /       %input#user-search-field.chat-group-form__input{:placeholder => "追加したいユーザー名を入力してください", :type => "text"}/
-    /     #user-search-result
-
-    / メンバー追加（collection_check_boxe用）
-    .chat-group-form__field
-      .chat-group-form__field--left
-        %label.chat-group-form__label{:for => "chat_group_チャットメンバー"} チャットメンバー
-      .chat-group-form__field--right
-        #chat-group-users
-          .chat-group-user
-            / ログインユーザーのチェックボックスは表示させないようにする
-            = collection_check_boxes(:group, :user_ids, User.where.not(id: current_user.id), :id, :name)
-
-    .chat-group-form__field
-      .chat-group-form__field--left
-      .chat-group-form__field--right
-        = f.submit 'Save', class: 'chat-group-form__action-btn'
+  =render 'group_form'


### PR DESCRIPTION
# WHAT
グループ編集画面の作成と、グループ編集機能の実装

# WHY
グループ管理機能に必須のため

### 補足
グループ作成画面(new.html.haml)とグループ 編集画面(edit.html.haml)の共通部分は部分テンプレート化（_group_form.html.haml）

### グループ編集画面↓
![2017-04-24 21 33 43](https://cloud.githubusercontent.com/assets/25572309/25337245/1389da40-2936-11e7-8a59-005b5ff53382.png)

