### PR TITLE
Add message sending function

### DIFF
--- a/app/assets/stylesheets/modules/_chat-main.scss
+++ b/app/assets/stylesheets/modules/_chat-main.scss
@@ -86,14 +86,14 @@
   background-color: #AAAAAA;
   height: 90px;
 
-  &-form{
+  .new_message{
     margin: 0 40px;
     position: relative;
 
     .chat-main__footer-body{
       position: relative;
 
-      .message{
+      #message_body{
         height: 20px;
         width: calc(100% - 135px);
         padding: 15px 10px;

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -2,8 +2,7 @@ class GroupsController < ApplicationController
 
   before_action :set_group, only: [:edit, :update]
 
-  def index
-  end
+  def index; end
 
   def new
     @group = Group.new

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -2,6 +2,9 @@ class GroupsController < ApplicationController
 
   before_action :set_group, only: [:edit, :update]
 
+  def index
+  end
+
   def new
     @group = Group.new
   end
@@ -9,7 +12,7 @@ class GroupsController < ApplicationController
   def create
     @group = Group.new(group_params)
     if @group.save
-      redirect_to root_path, notice: '新規グループが作成されました。'
+      redirect_to group_messages_path(@group), notice: '新規グループが作成されました。'
     else
       flash.now.alert = 'グループ名を入力して下さい'
       render :new
@@ -21,7 +24,7 @@ class GroupsController < ApplicationController
 
   def update
     if @group.update(group_params)
-      redirect_to root_path, notice: 'グループが更新されました'
+      redirect_to group_messages_path(@group), notice: 'グループが更新されました'
     else
       flash.now.alert = 'グループ名を入力して下さい'
       render :edit

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -8,7 +8,7 @@ class MessagesController < ApplicationController
   end
 
   def create
-    @message = Message.new(message_params)
+    @message = current_user.messages.new(message_params)
     if @message.save
       redirect_to group_messages_path(@group), notice: '新規メッセージが送信されました'
     else

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -1,4 +1,33 @@
 class MessagesController < ApplicationController
+
+  before_action :set_group
+  before_action :set_messages
+
   def index
+    @message = Message.new
   end
+
+  def create
+    @message = Message.new(message_params)
+    if @message.save
+      redirect_to group_messages_path(@group), notice: '新規メッセージが送信されました'
+    else
+      flash.now.alert = 'メッセージを入力して下さい'
+      render :index
+    end
+  end
+
+  private
+  def message_params
+    params.require(:message).permit(:body, :image).merge(group_id: params[:group_id], user_id: current_user.id)
+  end
+
+  def set_group
+    @group = Group.find(params[:group_id])
+  end
+
+  def set_messages
+    @messages = Message.where(group_id: params[:group_id])
+  end
+
 end

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -27,7 +27,7 @@ class MessagesController < ApplicationController
   end
 
   def set_messages
-    @messages = Message.where(group_id: params[:group_id])
+    @messages = @group.messages.includes(:user)
   end
 
 end

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -1,7 +1,6 @@
 class MessagesController < ApplicationController
 
-  before_action :set_group
-  before_action :set_messages
+  before_action :set_group,:set_messages, only: [:index, :create]
 
   def index
     @message = Message.new

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -5,6 +5,8 @@ class Group < ApplicationRecord
   has_many :group_users
   has_many :users, through: :group_users
 
+  has_many :messages
+
   # グループを新規作成・更新したときに、アソシエーション先であるusersも含めて保存・更新できるようにする
   accepts_nested_attributes_for :users
 

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -7,7 +7,4 @@ class Group < ApplicationRecord
 
   has_many :messages
 
-  # グループを新規作成・更新したときに、アソシエーション先であるusersも含めて保存・更新できるようにする
-  accepts_nested_attributes_for :users
-
 end

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -1,2 +1,4 @@
 class Message < ApplicationRecord
+  belongs_to :user
+  belongs_to :group
 end

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -1,0 +1,2 @@
+class Message < ApplicationRecord
+end

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -1,4 +1,7 @@
 class Message < ApplicationRecord
+
+  validates :body, presence: true
+
   belongs_to :user
   belongs_to :group
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,6 +7,8 @@ class User < ApplicationRecord
   has_many :group_users
   has_many :groups, through: :group_users
 
+  has_many :messages
+
   # allow users to update their accounts without passwords
   def update_without_current_password(params, *options)
     params.delete(:current_password)

--- a/app/views/groups/index.html.haml
+++ b/app/views/groups/index.html.haml
@@ -1,0 +1,1 @@
+= render 'shared/chat-side'

--- a/app/views/messages/_group.html.haml
+++ b/app/views/messages/_group.html.haml
@@ -1,6 +1,0 @@
-= link_to 'https://www.google.co.jp/' do
-  .chat-side__group
-    .chat-side__group-name
-      group-name
-    .chat-side__group-message
-      group-message

--- a/app/views/messages/_message.html.haml
+++ b/app/views/messages/_message.html.haml
@@ -1,7 +1,7 @@
 .chat-main__body--message
   .chat-main__body--message-name
-    username
+    #{message.user.name}
   .chat-main__body--message-time
-    2017/04/08 12:29:33
+    #{message.created_at}
   .chat-main__body--message-body
-    hoge
+    #{message.body}

--- a/app/views/messages/index.html.haml
+++ b/app/views/messages/index.html.haml
@@ -1,30 +1,13 @@
-.chat-side
+= render 'shared/chat-side'
 
-  .chat-side__user
-
-    .chat-side__user-content
-      .chat-side__user-name
-        = current_user.name
-      .chat-side__user--edit-user
-        = link_to edit_user_registration_path do
-          %i.fa.fa-cog
-      .chat-side__user--new-group
-        = link_to new_group_path do
-          %i.fa.fa-pencil-square-o
-
-  .chat-side__groups
-    .chat-side__groups-list
-      = render 'group'
-      = render 'group'
-      = render 'group'
 
 .chat-main
 
   .chat-main__header
     .chat-main__header--group
       .chat-main__header--group-name
-        groupname
-      = link_to 'Edit', 'https://www.google.co.jp/', :class => "chat-main__header--group-edit-btn"
+        = @group.name
+      = link_to 'Edit', edit_group_path(@group), class: "chat-main__header--group-edit-btn"
     .chat-main__header-members
       MEMBER:
       %i
@@ -36,15 +19,14 @@
 
   .chat-main__body
     .chat-main__body--messages-list
-      = render 'message'
-      = render 'message'
-      = render 'message'
+      - @messages.each do |message|
+        = render partial: 'message', locals: {message: message}
 
   .chat-main__footer
-    %form.chat-main__footer-form
+    =form_for [@group, @message] do |f|
       .chat-main__footer-body
-        %input.message{placeholder: "type a message"}
+        =f.text_field :body, placeholder: 'type a message'
         %label.chat-file
           %input.image
           %i.fa.fa-image
-      %input.submit{value: "Send"}
+      = f.submit 'Send', class: 'submit'

--- a/app/views/shared/_chat-side.html.haml
+++ b/app/views/shared/_chat-side.html.haml
@@ -1,0 +1,18 @@
+.chat-side
+
+  .chat-side__user
+
+    .chat-side__user-content
+      .chat-side__user-name
+        = current_user.name
+      .chat-side__user--edit-user
+        = link_to edit_user_registration_path do
+          %i.fa.fa-cog
+      .chat-side__user--new-group
+        = link_to new_group_path do
+          %i.fa.fa-pencil-square-o
+
+  .chat-side__groups
+    .chat-side__groups-list
+      - current_user.groups.each do |group|
+        = render partial: 'shared/group', locals: {group: group}

--- a/app/views/shared/_group.html.haml
+++ b/app/views/shared/_group.html.haml
@@ -1,0 +1,6 @@
+= link_to group_messages_path(group) do
+  .chat-side__group
+    .chat-side__group-name
+      = group.name
+    .chat-side__group-message
+      will show latest message here

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,9 @@ Rails.application.routes.draw do
   }
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 
-  resources :groups, except: [:show, :destroy]
+  resources :groups, except: [:show, :destroy] do
+    resources :messages, only: [:index, :create]
+  end
 
   root 'messages#index'
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,5 +8,5 @@ Rails.application.routes.draw do
     resources :messages, only: [:index, :create]
   end
 
-  root 'messages#index'
+  root 'groups#index'
 end

--- a/db/migrate/20170425074643_create_messages.rb
+++ b/db/migrate/20170425074643_create_messages.rb
@@ -1,0 +1,11 @@
+class CreateMessages < ActiveRecord::Migration[5.0]
+  def change
+    create_table :messages do |t|
+      t.text :body
+      t.string :image
+      t.references :group, foreign_key: true, null: false
+      t.references :user, foreign_key: true, null: false
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170422055753) do
+ActiveRecord::Schema.define(version: 20170425074643) do
 
   create_table "group_users", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer  "group_id",   null: false
@@ -25,6 +25,17 @@ ActiveRecord::Schema.define(version: 20170422055753) do
     t.string   "name",       null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+  end
+
+  create_table "messages", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+    t.text     "body",       limit: 65535
+    t.string   "image"
+    t.integer  "group_id",                 null: false
+    t.integer  "user_id",                  null: false
+    t.datetime "created_at",               null: false
+    t.datetime "updated_at",               null: false
+    t.index ["group_id"], name: "index_messages_on_group_id", using: :btree
+    t.index ["user_id"], name: "index_messages_on_user_id", using: :btree
   end
 
   create_table "users", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
@@ -48,4 +59,6 @@ ActiveRecord::Schema.define(version: 20170422055753) do
 
   add_foreign_key "group_users", "groups"
   add_foreign_key "group_users", "users"
+  add_foreign_key "messages", "groups"
+  add_foreign_key "messages", "users"
 end


### PR DESCRIPTION
# WHAT
メッセージ送信機能の実装
- メッセージ本文が未入力の場合はテーブルに保存されないようにバリデーションを設定
- messages#createアクションをバリデーションの結果に基づいて成功時と失敗時に分岐させ、それに応じて適切なフラッシュメッセージと画面遷移を設定

# WHY
チャットアプリに必要な機能のため

## 補足
同時に、以下の変更も加えました。
- トップページのパスをmessages#indexからgroups#indexに変更（左カラムにログインユーザーが参加しているグループ一覧を表示させ、メッセージ表示部分には何も表示させない）
- 部分テンプレートによるビューのリファクタリング


### メッセージ送信成功時↓
![2017-04-26 11 58 13](https://cloud.githubusercontent.com/assets/25572309/25416231/b55e8216-2a77-11e7-803d-03cf6a143c57.png)


### メッセージ送信失敗時↓
![2017-04-26 11 58 22](https://cloud.githubusercontent.com/assets/25572309/25416247/c7fccfcc-2a77-11e7-8c55-8fef9ad74cf3.png)


### トップページ（groups#index）↓
![2017-04-26 11 23 50](https://cloud.githubusercontent.com/assets/25572309/25416155/3de46412-2a77-11e7-997d-7ec53044a9e2.png)


### チャット画面（messages#index）↓
![2017-04-26 11 19 59](https://cloud.githubusercontent.com/assets/25572309/25416187/67e62caa-2a77-11e7-8c69-39ee59322410.png)


### ビューファイルと部分テンプレートの構成状況↓
- ↓の画面キャプチャーにて、開いている４つのビューファイルのディレクトリをハイライトさせています
- groups#indexとmessages#indexで共通で使用する部分テンプレートはsharedディレクトリにまとめました

**（１、左上）**
views/groups/index.html/haml
※トップページ　→　下記３を読み込んでいる

**（２、右上）**
views/messages/index.html/haml
※特定のグループのチャット画面　→　下記３を読み込んでいる

**（３、左下）**
views/**shared**/_chat-side.html/haml
※左カラム全体を表示する部分テンプレート　→　下記４を読み込んでいる

**（４、右下）**
views/**shared**/_group.html/haml
※左カラムの中の、ログインユーザーのグループ一覧を表示する部分テンプレート

![2017-04-26 11 18 21](https://cloud.githubusercontent.com/assets/25572309/25416293/0899ac44-2a78-11e7-8f65-4d625e8271ba.png)






