### PR TITLE
Unit test for messages controller

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -48,6 +48,7 @@ end
 
 group :test do
   gem 'faker'
+  gem 'rails-controller-testing'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -135,6 +135,10 @@ GEM
       bundler (>= 1.3.0, < 2.0)
       railties (= 5.0.2)
       sprockets-rails (>= 2.0.0)
+    rails-controller-testing (1.0.1)
+      actionpack (~> 5.x)
+      actionview (~> 5.x)
+      activesupport (~> 5.x)
     rails-dom-testing (2.0.2)
       activesupport (>= 4.2.0, < 6.0)
       nokogiri (~> 1.6)
@@ -228,6 +232,7 @@ DEPENDENCIES
   mysql2 (>= 0.3.13, < 0.5)
   pry-rails
   rails (~> 5.0.0, >= 5.0.0.1)
+  rails-controller-testing
   rspec-rails
   sass-rails (~> 5.0)
   sdoc (~> 0.4.0)

--- a/spec/controllers/messages_controller_spec.rb
+++ b/spec/controllers/messages_controller_spec.rb
@@ -1,0 +1,45 @@
+require 'rails_helper'
+
+describe MessagesController do
+
+    let(:group) { create(:group) }
+    let(:message) { create(:message, group_id: group.id)}
+
+    before do
+      user = create(:user)
+      login_user user
+    end
+
+    describe 'GET #index' do
+
+      it "assigns the new message to @message" do
+        get :index, params:{ group_id: group.id }
+        #ActualがMessageクラスのインスタンスであるかどうかをテスト
+        expect(assigns(:message)).to be_an_instance_of Message
+      end
+
+      it "renders the :index template" do
+        get :index, params:{ group_id: group.id }
+        expect(response).to render_template :index
+      end
+
+    end
+
+    describe 'POST #create' do
+
+      it "assigns the new message to @message with strong parameter" do
+        post :create, params:{ group_id: group.id, message: attributes_for(:message)}
+        expect(assigns(:message).body).to eq message.body
+        expect(assigns(:message).image).to eq message.image
+        expect(assigns(:message).group_id).to eq message.group_id
+        expect(assigns(:message).user_id).to eq message.user_id
+      end
+
+      it "redirects to messages#index" do
+        post :create, params:{ group_id: group.id, message: attributes_for(:message)}
+        expect(response).to redirect_to group_messages_path
+      end
+
+    end
+
+end

--- a/spec/controllers/messages_controller_spec.rb
+++ b/spec/controllers/messages_controller_spec.rb
@@ -12,6 +12,17 @@ describe MessagesController do
 
     describe 'GET #index' do
 
+      it "assigns the requested group to @group" do
+        get :index, params:{ group_id: group.id }
+        expect(assigns(:group)).to eq group
+      end
+
+      it "assigns the requested messages to @messages" do
+        messages = create_list(:message, 3 , group_id: group.id)
+        get :index, params:{ group_id: messages.first.group_id }
+        expect(assigns(:messages)).to match messages
+      end
+
       it "assigns the new message to @message" do
         get :index, params:{ group_id: group.id }
         #ActualがMessageクラスのインスタンスであるかどうかをテスト
@@ -27,6 +38,17 @@ describe MessagesController do
 
     describe 'POST #create' do
 
+      it "assigns the requested group to @group" do
+        get :index, params:{ group_id: group.id }
+        expect(assigns(:group)).to eq group
+      end
+
+      it "assigns the requested messages to @messages" do
+        messages = create_list(:message, 3 , group_id: group.id)
+        get :index, params:{ group_id: messages.first.group_id }
+        expect(assigns(:messages)).to match messages
+      end
+
       it "assigns the new message to @message with strong parameter" do
         post :create, params:{ group_id: group.id, message: attributes_for(:message)}
         expect(assigns(:message).body).to eq message.body
@@ -35,9 +57,24 @@ describe MessagesController do
         expect(assigns(:message).user_id).to eq message.user_id
       end
 
-      it "redirects to messages#index" do
-        post :create, params:{ group_id: group.id, message: attributes_for(:message)}
-        expect(response).to redirect_to group_messages_path
+      context 'if creating a message succeeded' do
+
+        it "redirects to messages#index" do
+          post :create, params:{ group_id: group.id, message: attributes_for(:message)}
+          expect(response).to redirect_to group_messages_path
+        end
+
+      end
+
+      context 'if creating a message failed' do
+
+        it "renders to messages#index" do
+          #bodyがブランクのparamsを渡すことで失敗時の状況を作る
+          post :create, params:{ group_id: group.id, message: attributes_for(:message, body: "")}
+          #リダイレクトではなくrenderなので、プレフィックスでテンプレートを指定することはできない
+          expect(response).to render_template :index
+        end
+
       end
 
     end

--- a/spec/factories/groups.rb
+++ b/spec/factories/groups.rb
@@ -1,0 +1,7 @@
+FactoryGirl.define do
+
+  factory :group do
+    name      { Faker::Name.name }
+  end
+
+end

--- a/spec/factories/messages.rb
+++ b/spec/factories/messages.rb
@@ -1,21 +1,10 @@
 FactoryGirl.define do
 
-  factory :user do
-    id        "1"
-    name      { Faker::Name.name }
-    email     { Faker::Internet.email }
-    password  { Faker::Internet.password }
-  end
-
   factory :message do
     body      "test_body"
     image     "test_imgae"
     group_id  "1"
     user_id   "1"
-  end
-
-  factory :group do
-    name      { Faker::Name.name }
   end
 
 end

--- a/spec/factories/messages.rb
+++ b/spec/factories/messages.rb
@@ -1,10 +1,21 @@
 FactoryGirl.define do
 
+  factory :user do
+    id        "1"
+    name      { Faker::Name.name }
+    email     { Faker::Internet.email }
+    password  { Faker::Internet.password }
+  end
+
   factory :message do
     body      "test_body"
     image     "test_imgae"
     group_id  "1"
     user_id   "1"
+  end
+
+  factory :group do
+    name      { Faker::Name.name }
   end
 
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,0 +1,10 @@
+FactoryGirl.define do
+
+  factory :user do
+    id        "1"
+    name      { Faker::Name.name }
+    email     { Faker::Internet.email }
+    password  { Faker::Internet.password }
+  end
+
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -31,6 +31,13 @@ RSpec.configure do |config|
   #factory_girlによってインスタンスを作成する際、レシーバーの記述を省略する
   config.include FactoryGirl::Syntax::Methods
 
+  # integrates with gem 'rails-controller-testing' to uses 'assings' in controller testing
+  [:controller, :view, :request].each do |type|
+    config.include ::Rails::Controller::Testing::TestProcess, :type => type
+    config.include ::Rails::Controller::Testing::TemplateAssertions, :type => type
+    config.include ::Rails::Controller::Testing::Integration, :type => type
+  end
+
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_path = "#{::Rails.root}/spec/fixtures"
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,3 +1,7 @@
+#ControllerMacrosでログイン状態を作ってテストを行う
+require 'devise'
+require 'support/controller_macros'
+
 # This file is copied to spec/ when you run 'rails generate rspec:install'
 ENV['RAILS_ENV'] ||= 'test'
 require File.expand_path('../../config/environment', __FILE__)
@@ -30,6 +34,12 @@ RSpec.configure do |config|
 
   #factory_girlによってインスタンスを作成する際、レシーバーの記述を省略する
   config.include FactoryGirl::Syntax::Methods
+
+  # deviseのテストヘルパーをロードする
+  config.include Devise::Test::ControllerHelpers, :type => :controller
+  config.include Devise::Test::ControllerHelpers, :type => :view
+  # 作成したログインモジュールを追加する
+  config.include ControllerMacros, type: :controller
 
   # integrates with gem 'rails-controller-testing' to uses 'assings' in controller testing
   [:controller, :view, :request].each do |type|

--- a/spec/support/controller_macros.rb
+++ b/spec/support/controller_macros.rb
@@ -1,0 +1,8 @@
+module ControllerMacros
+
+  def login_user(user)
+    @request.env["devise.mapping"] = Devise.mappings[:user]
+    sign_in user
+  end
+
+end


### PR DESCRIPTION
# WHAT
messagesコントローラーのテスト。indexアクションとcreateアクションそれぞれついて、以下の2つのテストを実施
- インスタンス変数が正しくセットされているかどうか
- ビューに正しく遷移するかどうか

# WHY
バグの無いサービスをリリースするため

## 設定についての補足
- gem 'rails-controller-testing'をインストールし、Rails5でもassignsを使ってテストできるように設定
- ControllerMacrosにより、ログイン認証された状態でテストを行えるように設定

## 行った４つのテスト

1. GET #indexアクション
インスタンス変数@messageが正しくセットされるかどうか
（生成されたインスタンスが、Messageクラスのインスタンスであるかどうかでテスト）

1. GET #indexアクション
GET #indexアクションに対応したビューが呼び出されているかどうか

1. POST #createアクション
ストロングパラメーターが入った状態のインスタンス変数@messageが正しくセットされるかどうか
（各カラムの中身をそれぞれ付け合わせることでテスト）

1. POST #createアクション
メッセージの保存に成功した時、messages#indexにリダイレクトされるかどうか

## メッセージコントローラーの状況
![2017-04-27 19 09 12](https://cloud.githubusercontent.com/assets/25572309/25478709/2f140472-2b7d-11e7-8dcc-4e51b7167815.png)




## テストの実行結果
![2017-04-27 18 52 40](https://cloud.githubusercontent.com/assets/25572309/25478075/c1cf06fc-2b7a-11e7-8064-cd8a1de9f921.png)
