### PR TITLE
Add incremental search function to group#create & group#edit 

### DIFF
--- a/app/assets/javascripts/user.js
+++ b/app/assets/javascripts/user.js
@@ -50,10 +50,10 @@ $(document).on("turbolinks:load", function() {
       })
 
       .done(function(data) {
-        for (var i = 0; i < data.length; i++){
-          var html = buildAddUserHTML(data[i]);
+        data.forEach(function(user){
+          var html = buildAddUserHTML(user);
           $('#user-search-result').append(html);
-        }
+        });
       })
 
       .fail(function() {

--- a/app/assets/javascripts/user.js
+++ b/app/assets/javascripts/user.js
@@ -1,0 +1,79 @@
+$(document).on("turbolinks:load", function() {
+
+  // 検索したユーザーのHTMLを組み立て
+  function buildHTML(user) {
+    var
+      html_name = '<p class="chat-group-user__name">' + user.name + '</p>',
+      html_btn = '<p class="chat-group-user__btn chat-group-user__btn--add" data-id = ' + user.id + '>' + '追加' + '</p>',
+      html = $('<div class="chat-group-user">').append([html_name, html_btn]);
+    return html;
+  }
+
+  // 追加するユーザーのHTMLを組み立て
+  function buildHTMLMember(user, id) {
+    var
+      html_input = '<input type = "hidden", value = ' + id + ', name = "group[user_ids][]", id ="group_user_ids_' + id + '">',
+      html_name = '<p class="chat-group-user__name">' + user + '</p>',
+      html_btn = '<p class="chat-group-user__btn chat-group-user__btn--remove">' + '削除' + '</p>',
+      html = $('<div class="chat-group-user">').append([html_input, html_name, html_btn]);
+    return html;
+  }
+
+  // グループ編集ページ（groups#edit）にて、
+  // 初期状態で表示されているメンバーの削除ボタンを機能させる
+  $(".chat-group-user__btn--remove").on("click", function() {
+    $(this).parent().remove();
+  });
+
+  $("#user_search_field").on("keyup", function() {
+    $("#user-search-result").children().remove();
+    var textField = $("#user_search_field");
+    var user = textField.val();
+
+    // 検索フィールドが空に戻った場合はajax通信を行わない
+    if (user == ""){
+
+    } else {
+
+      $.ajax({
+        type: 'GET',
+        url: '/users',
+        data: {
+          user: user
+        },
+        dataType: 'json'
+      })
+
+      .done(function(data) {
+        for (var i = 0; i < data.length; i++){
+          var html = buildHTML(data[i]);
+          $('#user-search-result').append(html);
+        }
+
+        $(".chat-group-user__btn--add").on("click", function() {
+          var user = $(this).prev().text();
+          // buildHTML内で付与したデータ属性からユーザーのidを取得する
+          var id = $(this).data('id');
+          var html = buildHTMLMember(user, id);
+          $('#chat-group-users').append(html);
+          $(this).parent().remove();
+
+            $(".chat-group-user__btn--remove").on("click", function() {
+              $(this).parent().remove();
+            });
+
+        });
+
+      })
+
+      .fail(function() {
+        alert('エラーが起きました');
+      });
+      // Turbolinksを止めないためにfalseを返しておく
+      return false;
+
+    }
+
+  });
+
+});

--- a/app/assets/javascripts/user.js
+++ b/app/assets/javascripts/user.js
@@ -83,7 +83,4 @@ $(document).on("turbolinks:load", function() {
   $("#chat-group-users").on("click", ".chat-group-user__btn--remove", function(){
     $(this).parent().remove();
   });
-
-
-
 });

--- a/app/assets/javascripts/user.js
+++ b/app/assets/javascripts/user.js
@@ -29,13 +29,8 @@ $(document).on("turbolinks:load", function() {
     return html;
   }
 
-  // グループ編集ページ（groups#edit）にて、
-  // 初期状態で表示されているメンバーの削除ボタンを機能させる
-  $(".chat-group-user__btn--remove").on("click", function() {
-    $(this).parent().remove();
-  });
-
-  $("#user_search_field").on("keyup", function() {
+  // ユーザー検索機能本体(インクリメンタルサーチ)
+  function searchUsers() {
     $("#user-search-result").children().remove();
     var textField = $("#user_search_field");
     var user = textField.val();
@@ -59,21 +54,6 @@ $(document).on("turbolinks:load", function() {
           var html = buildAddUserHTML(data[i]);
           $('#user-search-result').append(html);
         }
-
-        $(".chat-group-user__btn--add").on("click", function() {
-          var user = $(this).prev().text();
-          // buildHTML内で付与したデータ属性からユーザーのidを取得する
-          var id = $(this).data('id');
-          var html = buildMemberHTML(user, id);
-          $('#chat-group-users').append(html);
-          $(this).parent().remove();
-
-            $(".chat-group-user__btn--remove").on("click", function() {
-              $(this).parent().remove();
-            });
-
-        });
-
       })
 
       .fail(function() {
@@ -81,9 +61,29 @@ $(document).on("turbolinks:load", function() {
       });
       // Turbolinksを止めないためにfalseを返しておく
       return false;
-
     }
+  }
 
+  // ユーザー検索(インクリメンタルサーチ)の発火イベントの指定
+  $("#user_search_field").on("keyup", searchUsers);
+
+  // ユーザーを追加
+  // Ajaxで動的に継ぎ足した要素を直接セレクタに指定することは出来ないので、
+  // Ajaxが動く前から存在している要素を調査範囲に指定する
+  $("#user-search-result").on("click", ".chat-group-user__btn--add", function() {
+    var user = $(this).prev().text();
+    // buildHTML内で付与したデータ属性からユーザーのidを取得する
+    var id = $(this).data('id');
+    var html = buildMemberHTML(user, id);
+    $('#chat-group-users').append(html);
+    $(this).parent().remove();
   });
+
+  // ユーザーを削除
+  $("#chat-group-users").on("click", ".chat-group-user__btn--remove", function(){
+    $(this).parent().remove();
+  });
+
+
 
 });

--- a/app/assets/javascripts/user.js
+++ b/app/assets/javascripts/user.js
@@ -1,21 +1,31 @@
 $(document).on("turbolinks:load", function() {
 
   // 検索したユーザーのHTMLを組み立て
-  function buildHTML(user) {
-    var
-      html_name = '<p class="chat-group-user__name">' + user.name + '</p>',
-      html_btn = '<p class="chat-group-user__btn chat-group-user__btn--add" data-id = ' + user.id + '>' + '追加' + '</p>',
-      html = $('<div class="chat-group-user">').append([html_name, html_btn]);
+  function buildAddUserHTML(user) {
+    var html =
+      '<div class="chat-group-user">' +
+      '<p class="chat-group-user__name">' +
+      user.name +
+      '</p>' +
+      '<p class="chat-group-user__btn chat-group-user__btn--add" data-id = ' + user.id + '>' +
+      '追加' +
+      '</p>' +
+      '</div>';
     return html;
   }
 
   // 追加するユーザーのHTMLを組み立て
-  function buildHTMLMember(user, id) {
-    var
-      html_input = '<input type = "hidden", value = ' + id + ', name = "group[user_ids][]", id ="group_user_ids_' + id + '">',
-      html_name = '<p class="chat-group-user__name">' + user + '</p>',
-      html_btn = '<p class="chat-group-user__btn chat-group-user__btn--remove">' + '削除' + '</p>',
-      html = $('<div class="chat-group-user">').append([html_input, html_name, html_btn]);
+  function buildMemberHTML(user, id) {
+    var html =
+      '<div class="chat-group-user">' +
+      '<input type = "hidden", value = ' + id + ', name = "group[user_ids][]", id ="group_user_ids_' + id + '">' +
+      '<p class="chat-group-user__name">' +
+      user +
+      '</p>' +
+      '<p class="chat-group-user__btn chat-group-user__btn--remove">' +
+      '削除' +
+      '</p>' +
+      '</div>';
     return html;
   }
 
@@ -46,7 +56,7 @@ $(document).on("turbolinks:load", function() {
 
       .done(function(data) {
         for (var i = 0; i < data.length; i++){
-          var html = buildHTML(data[i]);
+          var html = buildAddUserHTML(data[i]);
           $('#user-search-result').append(html);
         }
 
@@ -54,7 +64,7 @@ $(document).on("turbolinks:load", function() {
           var user = $(this).prev().text();
           // buildHTML内で付与したデータ属性からユーザーのidを取得する
           var id = $(this).data('id');
-          var html = buildHTMLMember(user, id);
+          var html = buildMemberHTML(user, id);
           $('#chat-group-users').append(html);
           $(this).parent().remove();
 

--- a/app/assets/stylesheets/modules/groups.scss
+++ b/app/assets/stylesheets/modules/groups.scss
@@ -82,6 +82,14 @@
       padding: 10px 15px;
       box-sizing: border-box;
     }
+
+    #user_search_field {
+      float: left;
+      width: 100%;
+      line-height: 30px;
+      padding: 10px 15px;
+      box-sizing: border-box;
+    }
   }
 
   .chat-group-user {

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -6,6 +6,9 @@ class GroupsController < ApplicationController
 
   def new
     @group = Group.new
+    # 部分テンプレート「_group_form.html.haml」内で使用するダミー変数
+    # groups#newがリクエストされた際は、空の配列を渡すことでエラーを防ぐ
+    @users = []
   end
 
   def create
@@ -19,6 +22,9 @@ class GroupsController < ApplicationController
   end
 
   def edit
+    # 部分テンプレート「_group_form.html.haml」内で使用する変数
+    # groups#newがリクエストされた際に渡すことで、グループ編集画面にて、既に参加しているメンバーを始めから表示させる
+    @users = @group.users.where.not(id: current_user.id)
   end
 
   def update
@@ -32,9 +38,6 @@ class GroupsController < ApplicationController
 
   private
   def group_params
-    # ログインユーザーのidを、collection_check_boxes経由で送られてきた配列user_idsに、文字列型で追加する
-    params[:group][:user_ids].push(current_user.id.to_s)
-    # :user_idsは配列なので、書き方が↓のように特殊な形となる
     params.require(:group).permit(:name, user_ids: [])
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -3,7 +3,7 @@ class UsersController < ApplicationController
   def index
     @users = User.where('name LIKE(?)', "%#{user_params[:user]}%").where.not(id: current_user.id)
     respond_to do |format|
-      format.html { redirect_to new_group_path}
+      format.html { redirect_to new_group_path }
       format.json
     end
   end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,7 +1,7 @@
 class UsersController < ApplicationController
 
   def index
-    @users = User.where('name LIKE(?)', "#{user_params[:user]}%").where.not(id: current_user.id)
+    @users = User.where('name LIKE(?)', "%#{user_params[:user]}%").where.not(id: current_user.id)
     respond_to do |format|
       format.html { redirect_to new_group_path}
       format.json

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,0 +1,16 @@
+class UsersController < ApplicationController
+
+  def index
+    @users = User.where('name LIKE(?)', "#{user_params[:user]}%").where.not(id: current_user.id)
+    respond_to do |format|
+      format.html { redirect_to new_group_path}
+      format.json
+    end
+  end
+
+  private
+  def user_params
+    params.permit(:user)
+  end
+
+end

--- a/app/views/groups/_group_form.html.haml
+++ b/app/views/groups/_group_form.html.haml
@@ -27,11 +27,9 @@
           .chat-group-user
             %input{type: "hidden", value: current_user.id, name: "group[user_ids][]"}
             = content_tag(:p, current_user.name)
-
-          / groups#editがリクエストされた時に、グループに既に参加しているメンバーを表示させるための部分テンプレートを呼び出し
+          / groups#editがリクエストされた時に、グループに既に参加しているメンバーを表示させるための部分テンプレートの呼び出し
           / groups#newがリクエストされた場合は、@usersには空の配列がセットされるので、実際のビューには何も表示されない
-          - @users.each do |user|
-            = render partial: 'group_form_user', locals: {user: user}
+          = render partial: 'group_form_user', collection: @users, as: :user
 
     .chat-group-form__field
       .chat-group-form__field--left

--- a/app/views/groups/_group_form.html.haml
+++ b/app/views/groups/_group_form.html.haml
@@ -9,24 +9,29 @@
       .chat-group-form__field--right
         =f.text_field :name, placeholder: 'グループ名を入力してください'
 
-    / メンバー追加（インクリメンタルサーチ用）
-    / .chat-group-form__field
-    /   .chat-group-form__field--left
-    /     %label.chat-group-form__label{:for => "chat_group_チャットメンバーを追加"} チャットメンバーを追加
-    /   .chat-group-form__field--right
-    /     .chat-group-form__search
-    /       %input#user-search-field.chat-group-form__input{:placeholder => "追加したいユーザー名を入力してください", :type => "text"}/
-    /     #user-search-result
+    / インクリメンタルサーチ
+    .chat-group-form__field
+      .chat-group-form__field--left
+        %label.chat-group-form__label{:for => "chat_group_チャットメンバーを追加"} チャットメンバーを追加
+      .chat-group-form__field--right
+        .chat-group-form__search
+          = text_field_tag :user_search_field, nil, placeholder: '追加したいユーザー名を入力してください'
+        #user-search-result
 
-    / メンバー追加（collection_check_boxe用）
+    / インクリメンタルサーチ結果から追加されたメンバー一覧
     .chat-group-form__field
       .chat-group-form__field--left
         %label.chat-group-form__label{for: "chat_group_チャットメンバー"} チャットメンバー
       .chat-group-form__field--right
         #chat-group-users
           .chat-group-user
-            / ログインユーザーのチェックボックスは表示させないようにする
-            = collection_check_boxes(:group, :user_ids, User.where.not(id: current_user.id), :id, :name)
+            %input{type: "hidden", value: current_user.id, name: "group[user_ids][]"}
+            = content_tag(:p, current_user.name)
+
+          / groups#editがリクエストされた時に、グループに既に参加しているメンバーを表示させるための部分テンプレートを呼び出し
+          / groups#newがリクエストされた場合は、@usersには空の配列がセットされるので、実際のビューには何も表示されない
+          - @users.each do |user|
+            = render partial: 'group_form_user', locals: {user: user}
 
     .chat-group-form__field
       .chat-group-form__field--left

--- a/app/views/groups/_group_form_user.html.haml
+++ b/app/views/groups/_group_form_user.html.haml
@@ -1,0 +1,6 @@
+.chat-group-user
+  %input{type: "hidden", value: user.id, name: 'group[user_ids][]'}
+  %p.chat-group-user__name
+    = user.name
+  %p.chat-group-user__btn.chat-group-user__btn--remove
+    削除

--- a/app/views/users/index.json.jbuilder
+++ b/app/views/users/index.json.jbuilder
@@ -1,0 +1,4 @@
+json.(@users) do |user|
+  json.name user.name
+  json.id user.id
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,5 +8,7 @@ Rails.application.routes.draw do
     resources :messages, only: [:index, :create]
   end
 
+  resources :users, only: [:index]
+
   root 'groups#index'
 end


### PR DESCRIPTION
# WHAT
新規グループ作成画面(group#new)と、グループ編集画面(group#edit)のメンバー追加フォームにて、インクリメンタルサーチを実装。
同時に、インクリメンタルサーチの結果からユーザーを選択して、グループを新規作成・更新できるようにした。

# WHY
よりよいUI/UXを提供するため

## 補足
新規グループ作成画面(group#new)と、グループ編集画面(group#edit)は、部分テンプレートviews/groups/_group_form.html.hamlを共有しています。
グループ編集画面がリクエストされた際は、参加済みのユーザーを初期状態でチャットメンバー欄に表示させるために、さらに部分テンプレート（views/groups/_group_form_user.html.haml）を呼び出しています。この「_group_form_user.html.haml」内で表示させる参加済みのユーザー@usersを、groups_controller.rbのeditアクションに新たに定義しました。
新規グループ作成画面がリクエストされた際は、エラーにならないように、indexアクションに@usersを空の配列として定義しました。

## 実際の挙動（group#new）
<a href="https://gyazo.com/aaacf10d08b6ba8a11647b03ad91e14f"><img src="https://i.gyazo.com/aaacf10d08b6ba8a11647b03ad91e14f.gif" alt="https://gyazo.com/aaacf10d08b6ba8a11647b03ad91e14f" width="516"/></a>

## 実際の挙動（group#edit）
<a href="https://gyazo.com/6ce3ad6a7a82870df82df908433ea031"><img src="https://i.gyazo.com/6ce3ad6a7a82870df82df908433ea031.gif" alt="https://gyazo.com/6ce3ad6a7a82870df82df908433ea031" width="512"/></a>