### PR TITLE
Add post image function by Ajax using carrierwave 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,9 @@
 /log/*
 !/log/.keep
 /tmp
+
+public/uploads/message/image/10/20170503154947.jpg
+
+*.jpg
+
+*.png

--- a/.gitignore
+++ b/.gitignore
@@ -12,8 +12,7 @@
 !/log/.keep
 /tmp
 
-public/uploads/message/image/10/20170503154947.jpg
 
-*.jpg
-
-*.png
+#carrierwaveでアップロードした画像の変更履歴を無視する
+/public/uploads/message/image/*
+/public/uploads/tmp/*

--- a/Gemfile
+++ b/Gemfile
@@ -66,3 +66,7 @@ gem 'haml-rails'
 gem "font-awesome-rails"
 
 gem 'devise'
+
+# Image Uploader
+gem 'carrierwave'
+gem 'rmagick'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -44,6 +44,12 @@ GEM
       debug_inspector (>= 0.0.1)
     builder (3.2.3)
     byebug (9.0.6)
+    carrierwave (0.11.2)
+      activemodel (>= 3.2.0)
+      activesupport (>= 3.2.0)
+      json (>= 1.7)
+      mime-types (>= 1.16)
+      mimemagic (>= 0.3.0)
     coderay (1.1.1)
     coffee-rails (4.1.1)
       coffee-script (>= 2.2.0)
@@ -106,6 +112,7 @@ GEM
     mime-types (3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2016.0521)
+    mimemagic (0.3.2)
     mini_portile2 (2.1.0)
     minitest (5.10.1)
     multi_json (1.12.1)
@@ -154,6 +161,7 @@ GEM
     rdoc (4.3.0)
     responders (2.3.0)
       railties (>= 4.2.0, < 5.1)
+    rmagick (2.16.0)
     rspec-core (3.5.4)
       rspec-support (~> 3.5.0)
     rspec-expectations (3.5.0)
@@ -220,6 +228,7 @@ PLATFORMS
 
 DEPENDENCIES
   byebug
+  carrierwave
   coffee-rails (~> 4.1.0)
   devise
   erb2haml
@@ -233,6 +242,7 @@ DEPENDENCIES
   pry-rails
   rails (~> 5.0.0, >= 5.0.0.1)
   rails-controller-testing
+  rmagick
   rspec-rails
   sass-rails (~> 5.0)
   sdoc (~> 0.4.0)

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,35 +1,54 @@
 $(document).on("turbolinks:load", function() {
 
   function buildHTML(message) {
-    var
-      html_name =
-    $('<div class = "chat-main__body--message-name">').append(message.name),
-      html_time =
-    $('<div class = "chat-main__body--message-time">').append(message.created_at),
-      html_body =
-    $('<div class = "chat-main__body--message-body">').append(message.body),
-      html =
-    $('<div class = "chat-main__body--message">').append([html_name, html_time, html_body]);
+    // 画像がアップされないときは<img src = "null">となり余計なサムネが表示されることを防ぐ
+    if (message.image_url) {
+      var imageEle = '<img src = "' + message.image_url + '">';
+    } else {
+      var imageEle = '';
+    }
+
+    var html =
+      '<div class = "chat-main__body--message">' +
+      '<div class = "chat-main__body--message-name">' +
+      message.name +
+      '</div>' +
+      '<div class = "chat-main__body--message-time">' +
+      message.created_at +
+      '</div>' +
+      '<div class = "chat-main__body--message-body">' +
+      message.body +
+      '</div>' +
+      '<div class = "chat-main__body--message-image">' +
+      imageEle +
+      '</div>' +
+      '</div>';
     return html;
   }
 
+  // ファイル選択時にフォームを自動で送信する
+  $('#message_image').on('change', function(){
+    $(this).parents('#new_message').submit();
+  });
+
+  // フォームの非同期通信
   $('#new_message').on('submit', function(e) {
     // javascriptで作成したフラッシュメッセージを削除
     $('.notice-succsess').remove();
     $('.notice-error').remove();
     e.preventDefault();
     var textField = $('#message_body');
-    var message = textField.val();
+    var fileField = $('#message_image');
+
+    var formData = new FormData($(this).get()[0]);
 
     $.ajax({
       type: 'POST',
       url: $(this).attr('action'),
-      data: {
-        message: {
-          body: message,
-          image: 'image'
-        }
-      },
+      data: formData,
+      // Ajaxがdataを整形しない指定
+      processData: false,
+      contentType: false,
       dataType: 'json'
     })
 
@@ -40,6 +59,7 @@ $(document).on("turbolinks:load", function() {
       var notice = $('<p class = "notice-succsess">').append('新規メッセージが送信されました');
       $('.notice').append(notice);
       textField.val('');
+      fileField.val('');
     })
 
     .fail(function() {

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -37,10 +37,9 @@ $(document).on("turbolinks:load", function() {
     $('.notice-succsess').remove();
     $('.notice-error').remove();
     e.preventDefault();
-    var textField = $('#message_body');
-    var fileField = $('#message_image');
-
-    var formData = new FormData($(this).get()[0]);
+    var textField = $('#message_body'),
+        fileField = $('#message_image'),
+        formData = new FormData($(this).get()[0]);
 
     $.ajax({
       type: 'POST',

--- a/app/assets/stylesheets/modules/_chat-main.scss
+++ b/app/assets/stylesheets/modules/_chat-main.scss
@@ -108,7 +108,7 @@
         top: 35px;
         right: 135px;
 
-        .image{
+        #message_image{
           display: none;
         }
 

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -4,4 +4,7 @@ class Message < ApplicationRecord
 
   belongs_to :user
   belongs_to :group
+
+  mount_uploader :image, ImageUploader
+
 end

--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -1,0 +1,62 @@
+# encoding: utf-8
+
+class ImageUploader < CarrierWave::Uploader::Base
+
+  # Include RMagick or MiniMagick support:
+  include CarrierWave::RMagick
+  # include CarrierWave::MiniMagick
+
+  # Choose what kind of storage to use for this uploader:
+  storage :file
+  # storage :fog
+
+  # 画像の上限を300pxにする
+  process :resize_to_limit => [300, 300]
+
+  # 保存形式をJPGにする
+  process convert: 'jpg'
+
+  # Override the directory where uploaded files will be stored.
+  # This is a sensible default for uploaders that are meant to be mounted:
+  # 保存するディレクトリ名
+  def store_dir
+    "uploads/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
+  end
+
+  # Provide a default URL as a default if there hasn't been a file uploaded:
+  # def default_url
+  #   # For Rails 3.1+ asset pipeline compatibility:
+  #   # ActionController::Base.helpers.asset_path("fallback/" + [version_name, "default.png"].compact.join('_'))
+  #
+  #   "/images/fallback/" + [version_name, "default.png"].compact.join('_')
+  # end
+
+  # Process files as they are uploaded:
+  # process :scale => [200, 300]
+  #
+  # def scale(width, height)
+  #   # do something
+  # end
+
+  # Create different versions of your uploaded files:
+  # サムネイルを生成する設定 thumb バージョン(width 100px x height 100px)
+  version :thumb do
+    process :resize_to_fit => [100, 100]
+  end
+
+  # Add a white list of extensions which are allowed to be uploaded.
+  # For images you might use something like this:
+  # 許可する画像の拡張子
+  def extension_white_list
+    %w(jpg jpeg gif png)
+  end
+
+  # Override the filename of the uploaded files:
+  # Avoid using model.id or version_name here, see uploader/store.rb for details.
+  # 拡張子が同じでないとGIFをJPGとかにコンバートできないので、
+  # 変換したファイルのファイル名の規則を設定
+  def filename
+    "#{Time.now.strftime('%Y%m%d%H%M%S')}.jpg" if original_filename.present?
+  end
+
+end

--- a/app/views/messages/_message.html.haml
+++ b/app/views/messages/_message.html.haml
@@ -5,3 +5,6 @@
     = l(message.created_at, format: :custom)
   .chat-main__body--message-body
     = message.body
+  .chat-main__body--message-image
+    - if message.image?
+      = image_tag message.image.to_s

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -2,3 +2,4 @@ json.name @message.user.name
 # Railsのデフォルトの時刻表示形式に合わせる
 json.created_at l(@message.created_at, format: :custom)
 json.body @message.body
+json.image_url @message.image.url

--- a/app/views/messages/index.html.haml
+++ b/app/views/messages/index.html.haml
@@ -27,6 +27,6 @@
       .chat-main__footer-body
         =f.text_field :body, placeholder: 'type a message'
         %label.chat-file
-          %input.image
+          = f.file_field :image
           %i.fa.fa-image
       = f.submit 'Send', class: 'submit'


### PR DESCRIPTION
# WHAT
carrierwaveを用いて、非同期で画像を投稿できるようにする

# WHY
投稿できる種類を増やすため

## 補足
- ファイルが選択された瞬間に、自動的にフォームがsubmitされ、非同期通信が行われるように設定しました
- FormDataを用いて、フォームに入力された内容をひとまとまりにし、それをajaxで送信するdataに設定しました。（これにより、message#createアクション（メッセージ送信機能のAPI）の既存のストロングパラメーターで、フォームに入力された内容を取り出すことができる）

## 画像UP時の画面の挙動
[![https://gyazo.com/2651bacbcf0580347c0b164ce99063db](https://i.gyazo.com/2651bacbcf0580347c0b164ce99063db.gif)](https://gyazo.com/2651bacbcf0580347c0b164ce99063db)

