### PR TITLE
Add auto refresh function

### DIFF
--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -29,6 +29,12 @@ $(document).on("turbolinks:load", function() {
     return html;
   }
 
+  // 最新のメッセージが表示されるように自動でスクロールする
+  function autoScrollToBottom(){
+    var targetY = $('.chat-main__body--messages-list').height();
+    $('.chat-main__body').scrollTop(targetY);
+  }
+
   // ファイル選択時にフォームを自動で送信する
   $('#message_image').on('change', function(){
     $(this).parents('#new_message').submit();
@@ -57,6 +63,7 @@ $(document).on("turbolinks:load", function() {
     .done(function(data) {
       var html = buildHTML(data);
       $('.chat-main__body--messages-list').append(html);
+      autoScrollToBottom();
       // javascriptでフラッシュメッセージを作成
       var notice = $('<p class = "notice-succsess">').append('新規メッセージが送信されました');
       $('.notice').append(notice);
@@ -97,6 +104,7 @@ $(document).on("turbolinks:load", function() {
           var html = buildHTML(message_add);
           $('.chat-main__body--messages-list').append(html);
         });
+        autoScrollToBottom();
       }
     })
 

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,6 +1,7 @@
 $(document).on("turbolinks:load", function() {
 
   function buildHTML(message) {
+
     // 画像がアップされないときは<img src = "null">となり余計なサムネが表示されることを防ぐ
     if (message.image_url) {
       var imageEle = '<img src = "' + message.image_url + '">';
@@ -9,7 +10,9 @@ $(document).on("turbolinks:load", function() {
     }
 
     var html =
-      '<div class = "chat-main__body--message">' +
+      '<div class = "chat-main__body--message" data-message-id = ' +
+      message.id +
+      '>' +
       '<div class = "chat-main__body--message-name">' +
       message.name +
       '</div>' +
@@ -68,4 +71,38 @@ $(document).on("turbolinks:load", function() {
     // Turbolinksを止めないためにfalseを返しておく
     return false;
   });
+
+  // 10秒間隔で、インターバル中に投稿されたメッセージを非同期で取得し表示する
+  setInterval(function(){
+
+    // 特定のグループの最後に投稿されたメッセージのidを取得する
+    // まだメッセージが投稿されていない場合は、0を代入する
+    // ||の左側の要素があればそれを代入、なければ右側の値を代入
+    var lastMessageID = $('.chat-main__body--message').last().data('message-id') || 0;
+
+    // APIに最後のメッセージのidを送り、そのidより大きいメッセージがあれば返してもらう
+    $.ajax({
+      type: 'GET',
+      url: './messages',
+      data: {
+        lastMessageID: lastMessageID
+      },
+      dataType: 'json'
+    })
+
+    .done(function(data) {
+      data.forEach(function(message_add){
+        var html = buildHTML(message_add);
+        $('.chat-main__body--messages-list').append(html);
+      });
+    })
+
+    .fail(function() {
+      alert('エラーが生じました');
+    });
+    // Turbolinksを止めないためにfalseを返しておく
+    return false;
+    },
+    10000);
+
 });

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -80,40 +80,49 @@ $(document).on("turbolinks:load", function() {
   });
 
   // 10秒間隔で、インターバル中に投稿されたメッセージを非同期で取得し表示する
-  setInterval(function(){
+  // 別ページに遷移した際にclearIntervalでsetIntervalを止める必要があるため、setIntervalを変数化する
+  var autoReload = setInterval(function(){
 
-    // 特定のグループの最後に投稿されたメッセージのidを取得する
-    // まだメッセージが投稿されていない場合は、0を代入する
-    // ||の左側の要素があればそれを代入、なければ右側の値を代入
-    var lastMessageID = $('.chat-main__body--message').last().data('message-id') || 0;
+    // URLがmessages#indexのパスと等しいときにのみ、Ajaxを起動する
+    if(location.pathname.match(/\/groups\/\d+\/messages/)){
 
-    // APIに最後のメッセージのidを送り、そのidより大きいメッセージがあれば返してもらう
-    $.ajax({
-      type: 'GET',
-      url: './messages',
-      data: {
-        lastMessageID: lastMessageID
-      },
-      dataType: 'json'
-    })
+      // 特定のグループの最後に投稿されたメッセージのidを取得する
+      // まだメッセージが投稿されていない場合は、0を代入する
+      // ||の左側の要素があればそれを代入、なければ右側の値を代入
+      var lastMessageID = $('.chat-main__body--message').last().data('message-id') || 0;
 
-    .done(function(data) {
-      // 配列dataの要素数が1以上のときのみHTMLを組成する
-      if (data.length){
-        data.forEach(function(message_add){
-          var html = buildHTML(message_add);
-          $('.chat-main__body--messages-list').append(html);
-        });
-        autoScrollToBottom();
-      }
-    })
+      // APIに最後のメッセージのidを送り、そのidより大きいメッセージがあれば返してもらう
+      $.ajax({
+        type: 'GET',
+        url: './messages',
+        data: {
+          lastMessageID: lastMessageID
+        },
+        dataType: 'json'
+      })
 
-    .fail(function() {
-      alert('エラーが生じました');
-    });
-    // Turbolinksを止めないためにfalseを返しておく
-    return false;
-    },
-    10000);
+      .done(function(data) {
+        // 配列dataの要素数が1以上のときのみHTMLを組成する
+        if (data.length){
+          data.forEach(function(message_add){
+            var html = buildHTML(message_add);
+            $('.chat-main__body--messages-list').append(html);
+          });
+          autoScrollToBottom();
+        }
+      })
+
+      .fail(function() {
+        alert('エラーが生じました');
+      });
+      // Turbolinksを止めないためにfalseを返しておく
+      return false;
+
+    } else {
+    // 別ページに遷移したらsetIntervalを停止させる
+    clearInterval(autoReload);
+    }
+
+  }, 10000);
 
 });

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -91,10 +91,13 @@ $(document).on("turbolinks:load", function() {
     })
 
     .done(function(data) {
-      data.forEach(function(message_add){
-        var html = buildHTML(message_add);
-        $('.chat-main__body--messages-list').append(html);
-      });
+      // 配列dataの要素数が1以上のときのみHTMLを組成する
+      if (data.length){
+        data.forEach(function(message_add){
+          var html = buildHTML(message_add);
+          $('.chat-main__body--messages-list').append(html);
+        });
+      }
     })
 
     .fail(function() {

--- a/app/assets/stylesheets/modules/_chat-main.scss
+++ b/app/assets/stylesheets/modules/_chat-main.scss
@@ -46,6 +46,7 @@
 
 .chat-main__body{
   height: calc(100vh - 15% - 90px);
+  overflow-y: scroll;
 
   &--messages-list{
     padding: 26px 40px 0;

--- a/app/assets/stylesheets/modules/_chat-side.scss
+++ b/app/assets/stylesheets/modules/_chat-side.scss
@@ -54,6 +54,7 @@
 
   &-list{
     height: 100%;
+    overflow-y: scroll;
 
     .chat-side__group{
       padding: 20px;

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -4,6 +4,14 @@ class MessagesController < ApplicationController
 
   def index
     @message = Message.new
+    respond_to do |format|
+      format.html
+      format.json do
+        # @messages_addはHTMLリクエストに対しては生成不要なので、format.json内に入れ子にして定義
+        # idが、ajaxで送られてきた最後のメッセージのidよりも大きいメッセージを取得
+        @messages_add = Message.where(group_id: params[:group_id]).where('id > ?', params[:lastMessageID])
+      end
+    end
   end
 
   def create

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -9,7 +9,7 @@ class MessagesController < ApplicationController
       format.json do
         # @messages_addはHTMLリクエストに対しては生成不要なので、format.json内に入れ子にして定義
         # idが、ajaxで送られてきた最後のメッセージのidよりも大きいメッセージを取得
-        @messages_add = Message.where(group_id: params[:group_id]).where('id > ?', params[:lastMessageID])
+        @messages_add = @group.messages.where('id > ?', params[:lastMessageID])
       end
     end
   end

--- a/app/views/messages/_message.html.haml
+++ b/app/views/messages/_message.html.haml
@@ -1,4 +1,4 @@
-.chat-main__body--message
+.chat-main__body--message{data: {message_id: message.id}}
   .chat-main__body--message-name
     = message.user.name
   .chat-main__body--message-time

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -3,3 +3,4 @@ json.name @message.user.name
 json.created_at l(@message.created_at, format: :custom)
 json.body @message.body
 json.image_url @message.image.url
+json.id @message.id

--- a/app/views/messages/index.json.jbuilder
+++ b/app/views/messages/index.json.jbuilder
@@ -1,0 +1,8 @@
+json.(@messages_add) do |messages_add|
+  json.name messages_add.user.name
+  # Railsのデフォルトの時刻表示形式に合わせる
+  json.created_at l(messages_add.created_at, format: :custom)
+  json.body messages_add.body
+  json.image_url messages_add.image.url
+  json.id messages_add.id
+end


### PR DESCRIPTION
# WHAT
設定したインターバル（１０秒）中に他のユーザーが投稿したメッセージが、メッセージ一覧ページに非同期で表示されるように実装する。（ページの自動更新）
SQLの発行回数を減らすため、投稿済みのメッセージの全てを自動更新するのではなく、インターバル中に投稿されたメッセージ（前回のインターバル終了時点からの差分）のみを非同期で取得し、表示する。

# WHY
アプリケーションのリアルタイム性を高め、よりよいUXを提供するため

## インターバル中に投稿されたメッセージをAPI（messages#index）で取得するロジック
**STEP１**
各メッセージを表示しているdivタグ（.chat-main__body--message）に、メッセージのidをカスタムデータ属性として持たせる
![2017-05-05 13 15 53](https://cloud.githubusercontent.com/assets/25572309/25733531/01079b48-3195-11e7-9676-0b5b0f4aa4a9.png)

↓
**STEP２**
javascriptにて、最後に投稿されたメッセージのdivタグからSTEP１で設定したidを取得し、API（messages#index）に送る。
まだメッセージが投稿されていない場合は、0をidとして代入する。（undefinedが代入されるのを防ぎ、APIでインターバル中に投稿された全てのメッセージを取得するため）
![2017-05-05 13 17 50](https://cloud.githubusercontent.com/assets/25572309/25733571/4cb9bda0-3195-11e7-99a7-37e3264e776d.png)

↓
**STEP３**
API（messages#index）にて、idの値がajaxで送られてきたidよりも大きいメッセージを取得し、javascriptに返す
![2017-05-05 13 22 29](https://cloud.githubusercontent.com/assets/25572309/25733610/f617d90e-3195-11e7-896f-a8aefe47b1a5.png)

↓
**STEP４**
APIから返ってきたメッセージ（配列）をforEachを使ってHTMLを組成する
（配列が空の場合（インターバル中に何も投稿されなかった場合）はforEachが起動せず、HTMLも組成されない）


## 画面の挙動（上の画面にメッセージを入力）
[![https://gyazo.com/d0c3c2437b35598ce4f6940737009ed8](https://i.gyazo.com/d0c3c2437b35598ce4f6940737009ed8.gif)](https://gyazo.com/d0c3c2437b35598ce4f6940737009ed8)