### PR TITLE
Some minor updates in massages#index view

### DIFF
--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -7,4 +7,8 @@ class Group < ApplicationRecord
 
   has_many :messages
 
+  def show_lastest_message
+    (messages.last)? messages.last.body : 'まだメッセージはありません'
+  end
+
 end

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -8,7 +8,7 @@ class Group < ApplicationRecord
   has_many :messages
 
   def show_lastest_message
-    (messages.last)? messages.last.body : 'まだメッセージはありません'
+    messages.last.try(:body) || 'まだメッセージはありません'
   end
 
 end

--- a/app/views/messages/index.html.haml
+++ b/app/views/messages/index.html.haml
@@ -10,12 +10,9 @@
       = link_to 'Edit', edit_group_path(@group), class: "chat-main__header--group-edit-btn"
     .chat-main__header-members
       MEMBER:
-      %i
-        user1
-      %i
-        user2
-      %i
-        user3
+      - @group.users.each do |user|
+        %i
+          = user.name
 
   .chat-main__body
     .chat-main__body--messages-list

--- a/app/views/shared/_group.html.haml
+++ b/app/views/shared/_group.html.haml
@@ -3,4 +3,4 @@
     .chat-side__group-name
       = group.name
     .chat-side__group-message
-      will show latest message here
+      = group.show_lastest_message


### PR DESCRIPTION
# WHAT
- グループに参加しているユーザーの一覧を、ページの右カラム上部のグループ名の下に表示させる
- 各グループの最後に投稿されたメッセージを、左カラムのグループ一覧の各グループ名の下に表示させる（まだメッセージが投稿されていない場合はその旨を記載する）

# WHY
ユーザービリティ向上のため

### 画面キャプチャー 
![2017-05-06 14 50 50](https://cloud.githubusercontent.com/assets/25572309/25770240/6db10262-326b-11e7-94ff-332ff4d86a0d.png)
