### PR TITLE
bug fix (not to build HTML when posting a blank message)

### DIFF
--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -23,7 +23,6 @@ class MessagesController < ApplicationController
       end
     else
       flash.now.alert = 'メッセージを入力して下さい'
-      render :index
     end
   end
 


### PR DESCRIPTION
# WHAT
非同期でメッセージを投稿する際、メッセージ未入力状態でもajaxによりHTMLが組成されてしまっていた（バリデーションにはひっかかりDBには保存されない）ため、修正を行った

# WHY
ユーザーの混乱を防ぐため

## バグの原因
メッセージ未入力状態の場合はバリデーションにひっかかり、message#createアクション内の@messge.saveがfalseになり、else文に分岐することは確認できた（jsonをmessage.jsに返す動きは行われず、また、DBにも保存されない）。
しかし、render :indexの記述があることで、何故かもう一度非同期通信が行われてしまい、かつそれが成功してしまうため、undefined状態のHTMLが組成されてしまっていた。

## 修正前のmessage#createアクションの状況
![2017-05-06 18 48 54](https://cloud.githubusercontent.com/assets/25572309/25771452/b5fa5020-328c-11e7-97ce-45cee0b24e8a.png)

## 対応
render :indexが原因であることは突き止められたものの、具体的にどう悪影響していたのか（なぜもう一度Ajaxが起動してしまったのか、そしてなぜAjaxの通信が成功してしまったのか）は要調査だが、一旦バグを消すことを優先する。
message#createアクションからrender :indexの記述を削除し、以下の挙動に問題が無いことを確認した。
- 非同期でのメッセージ送信
- 非同期での画像送信
- 非同期での自動更新



